### PR TITLE
Fix encoding issues for track names, artist names, paths and search queries when they contain non ascii characters

### DIFF
--- a/onthego/download.py
+++ b/onthego/download.py
@@ -9,6 +9,8 @@ import onthego.youtube
 def audio(track_name, artist, directory,
         skip_existing=True, convert_to_mp3=True):
 
+    artist = artist.encode("utf-8")
+    track_name = track_name.encode("utf-8")
     if should_skip(track_name, artist, directory, skip_existing, convert_to_mp3):
         print("++ Skipping %s - %s" % (artist, track_name))
         return

--- a/onthego/youtube.py
+++ b/onthego/youtube.py
@@ -14,7 +14,7 @@ def download_to_tmp(track_name, artist):
     best = video.getbestaudio()
 
     tmp_path = get_tmp_path(best)
-    print("    Downloading %s to %s" % (swf_url, tmp_path))
+    print("    Downloading %s to %s" % (swf_url, tmp_path.encode("utf-8")))
     best.download(tmp_path)
     return tmp_path
 
@@ -29,7 +29,10 @@ def get_search_query(track_name, artist):
 def get_first_search_result(search_query):
     yt_service = gdata.youtube.service.YouTubeService()
     query = gdata.youtube.service.YouTubeVideoQuery()
-    query.vq = search_query.encode("utf-8")
+    try:
+        query.vq = search_query.encode("utf-8")
+    except UnicodeDecodeError:
+        query.vq = search_query
     feed = yt_service.YouTubeQuery(query)
     # return first entry with valid swf url
     for entry in feed.entry:


### PR DESCRIPTION
I was trying to download a couple of playlists:
spotify:user:miguegs:playlist:0drqDMsC280akTPmFJhljj
spotify:user:raulcumplido:playlist:62SibcIG7nED4uLiRvcEcn

I´ve found that if the name of the artist or the track contains non-ascii characters it fails:

```
Traceback (most recent call last):
  File "/Users/raulcd/Envs/spotify-onthego/bin/spotify-onthego", line 9, in <module>
    load_entry_point('spotify-onthego==0.0.1', 'console_scripts', 'spotify-onthego')()
  File "/Users/raulcd/Projects/spotify-onthego/onthego/scripts/cli.py", line 24, in download_playlist
    skip_existing=(not args.no_skip), convert_to_mp3=(not args.no_convert))
  File "/Users/raulcd/Projects/spotify-onthego/onthego/download.py", line 17, in audio
    audio_file_path = onthego.youtube.download_to_tmp(track_name, artist)
  File "/Users/raulcd/Projects/spotify-onthego/onthego/youtube.py", line 17, in download_to_tmp
    print("    Downloading %s to %s" % (swf_url, tmp_path))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf1' in position 183: ordinal not in range(128)
```

This fixes the possible errors.
