### PR TITLE
Add owner of playlist to the download information

### DIFF
--- a/onthego/spotify/auth.py
+++ b/onthego/spotify/auth.py
@@ -142,16 +142,18 @@ class Client(object):
         self.spotify = spotipy.Spotify(auth=token)
 
     def iter_tracks(self, playlist_name):
-        playlist_id = self.get_playlist_id(playlist_name)
-        print("Downloading playlist '%s' (id=%s)" % (playlist_name, playlist_id))
-        for item in self.spotify.user_playlist(self.spotify_username, playlist_id)["tracks"]["items"]:
+        playlist_id, playlist_owner = self.get_playlist_id_info(playlist_name)
+        print("Downloading playlist '%s' (id=%s) from owner '%s'" % (
+            playlist_name, playlist_id, playlist_owner)
+        )
+        for item in self.spotify.user_playlist(playlist_owner, playlist_id)["tracks"]["items"]:
             track = item["track"]
             yield track["name"], track["artists"][0]["name"]
 
-    def get_playlist_id(self, name):
-        for playlist_id, playlist_name in self.iter_playlists():
+    def get_playlist_id_info(self, name):
+        for playlist_id, playlist_name, playlist_owner in self.iter_playlists():
             if playlist_name == name:
-                return playlist_id
+                return playlist_id, playlist_owner
         raise PlaylistNotFound(name)
 
     def iter_playlists(self):
@@ -163,7 +165,7 @@ class Client(object):
                 break
             offset += limit
             for playlist in playlists:
-                yield playlist["id"], playlist["name"]
+                yield playlist["id"], playlist["name"], playlist['owner']['id']
 
 class PlaylistNotFound(ValueError):
 


### PR DESCRIPTION
I´ve found that when you are not the owner of a playlist, but a follower you cannot download it, it fails because it cannot find the playlist at the URL https://api.spotify.com/v1/users/raulcumplido/playlists/4LIpFOsgMFanDAvsNOPy1P because the playlist is not from my user:

```
Downloading playlist 'Dover' (id=4LIpFOsgMFanDAvsNOPy1P)
Traceback (most recent call last):
  File "/Users/raulcd/Envs/spotify-onthego/bin/spotify-onthego", line 9, in <module>
    load_entry_point('spotify-onthego==0.0.1', 'console_scripts', 'spotify-onthego')()
  File "/Users/raulcd/Projects/spotify-onthego/onthego/scripts/cli.py", line 22, in download_playlist
    for track_name, artist in spotify_client.iter_tracks(args.playlist):
  File "/Users/raulcd/Projects/spotify-onthego/onthego/spotify/auth.py", line 147, in iter_tracks
    for item in self.spotify.user_playlist(self.spotify_username, playlist_id)["tracks"]["items"]:
  File "/Users/raulcd/Envs/spotify-onthego/lib/python2.7/site-packages/spotipy/client.py", line 290, in user_playlist
    return self._get("users/%s/playlists/%s" % (user, plid), fields=fields)
  File "/Users/raulcd/Envs/spotify-onthego/lib/python2.7/site-packages/spotipy/client.py", line 98, in _get
    return self._internal_call('GET', url, payload, kwargs)
  File "/Users/raulcd/Envs/spotify-onthego/lib/python2.7/site-packages/spotipy/client.py", line 85, in _internal_call
    -1, u'%s:\n %s' % (r.url, r.json()['error']['message']))
spotipy.client.SpotifyException: http status: 404, code:-1 - https://api.spotify.com/v1/users/raulcumplido/playlists/4LIpFOsgMFanDAvsNOPy1P:
 Not found.
```

You can fix manually by modifying the file on `~/.local/share/spotify-onthego/credentials.json` and the `username` but the proposed fix solves the issue.
