### PR TITLE
Fix missing album info

### DIFF
--- a/onthego/id3.py
+++ b/onthego/id3.py
@@ -8,15 +8,18 @@ def tag(filepath, track):
     audiofile = eyed3.load(filepath)
     audiofile.tag.artist = track.artist
     audiofile.tag.title = track.name
-    audiofile.tag.album = track.album_name
-    audiofile.date = track.album_release_date
+    if track.album_name:
+        audiofile.tag.album = track.album_name
+    if track.album_release_date:
+        audiofile.date = track.album_release_date
 
     # Get album art image
-    image_data = requests.get(track.album_art_url).content
-    audiofile.tag.images.set(
-        3,# 3 means 'front cover'
-        image_data,
-        "image/jpeg"
-    )
+    if track.album_art_url:
+        image_data = requests.get(track.album_art_url).content
+        audiofile.tag.images.set(
+            3,# 3 means 'front cover'
+            image_data,
+            "image/jpeg"
+        )
 
     audiofile.tag.save()

--- a/onthego/spotify.py
+++ b/onthego/spotify.py
@@ -38,8 +38,10 @@ class Client(object):
         Album information is fetched and added to the Track object.
         """
         # fetch album info
-        album = self.spotify.album(api_track_result["album"]["id"])
-        return Track(api_track_result["name"], api_track_result["artists"], album)
+        album_id = api_track_result["album"]["id"]
+        album = self.spotify.album(album_id) if album_id else None
+
+        return Track(api_track_result["name"], api_track_result["artists"], album=album)
 
     def iter_playlists(self):
         """Iterate on all user playlists
@@ -62,27 +64,21 @@ class Client(object):
 
 class Track(object):
 
-    def __init__(self, name, artists, album):
+    def __init__(self, name, artists, album=None):
         self.name = name
-        self.album = album
         self.artists = artists
+        if album:
+            self.album_name = album["name"]
+            self.album_art_url = album["images"][0]["url"]
+            # Note that release dates are encoded in Spotify as '%Y-%m-%d',
+            # '%Y-%m' or '%Y'. If you wish to obtain just the release year, the first
+            # 4 characters should suffice.
+            self.album_release_date = album['release_date']
+        else:
+            self.album_name = None
+            self.album_art_url = None
+            self.album_release_date = None
 
     @property
     def artist(self):
         return self.artists[0]["name"]
-
-    @property
-    def album_name(self):
-        return self.album["name"]
-
-    @property
-    def album_art_url(self):
-        return self.album["images"][0]["url"]
-
-    @property
-    def album_release_date(self):
-        """Note that release dates are encoded in Spotify as '%Y-%m-%d',
-        '%Y-%m' or '%Y'. If you wish to obtain just the release year, the first
-        4 characters should suffice.
-        """
-        return self.album['release_date']


### PR DESCRIPTION
In some cases, the album ID associated to a track is absent. It is then
impossible to fetch the information associated to the album, and the
corresponding id3 tags cannot be filled.